### PR TITLE
Migrate to Manifest V3 and add cross-browser compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 chrome.zip
+firefox.zip
+.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,12 @@
-build: chrome.zip
+.PHONY: all clean
 
-chrome.zip: manifest.json newlove.user.js
-	zip chrome.zip manifest.json newlove.user.js
+all: chrome.zip firefox.zip
+
+chrome.zip: manifest.json newlove.user.js browser-polyfill.js
+	zip chrome.zip manifest.json newlove.user.js browser-polyfill.js
+
+firefox.zip: manifest.json newlove.user.js browser-polyfill.js
+	zip firefox.zip manifest.json newlove.user.js browser-polyfill.js
+
+clean:
+	rm -f chrome.zip firefox.zip

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@
 all: chrome.zip firefox.zip
 
 chrome.zip: manifest.json newlove.user.js browser-polyfill.js
-	zip chrome.zip manifest.json newlove.user.js browser-polyfill.js
+	zip -r chrome.zip manifest.json newlove.user.js browser-polyfill.js
 
 firefox.zip: manifest.json newlove.user.js browser-polyfill.js
-	zip firefox.zip manifest.json newlove.user.js browser-polyfill.js
+	zip -r firefox.zip manifest.json newlove.user.js browser-polyfill.js
 
 clean:
 	rm -f chrome.zip firefox.zip

--- a/browser-polyfill.js
+++ b/browser-polyfill.js
@@ -9,16 +9,14 @@
                     set: (items) => chrome.storage.local.set(items),
                     remove: (keys) => chrome.storage.local.remove(keys)
                 }
-            },
-            runtime: {
-                onInstalled: chrome.runtime.onInstalled
-            },
-            contextMenus: {
-                create: (options) => chrome.contextMenus?.create(options)
             }
         };
     } else if (typeof browser !== 'undefined') {
         // Firefox already has the browser.* namespace
         global.browser = browser;
     }
+    
+    // Dispatch an event to notify that the polyfill is ready
+    const event = new Event('browser-polyfill-ready');
+    global.dispatchEvent(event);
 })(typeof globalThis !== 'undefined' ? globalThis : typeof window !== 'undefined' ? window : this);

--- a/browser-polyfill.js
+++ b/browser-polyfill.js
@@ -1,0 +1,24 @@
+// Cross-browser compatibility layer
+(function(global, factory) {
+    if (typeof chrome !== 'undefined') {
+        // Chrome uses the chrome.* namespace
+        global.browser = {
+            storage: {
+                local: {
+                    get: (keys) => chrome.storage.local.get(keys),
+                    set: (items) => chrome.storage.local.set(items),
+                    remove: (keys) => chrome.storage.local.remove(keys)
+                }
+            },
+            runtime: {
+                onInstalled: chrome.runtime.onInstalled
+            },
+            contextMenus: {
+                create: (options) => chrome.contextMenus?.create(options)
+            }
+        };
+    } else if (typeof browser !== 'undefined') {
+        // Firefox already has the browser.* namespace
+        global.browser = browser;
+    }
+})(typeof globalThis !== 'undefined' ? globalThis : typeof window !== 'undefined' ? window : this); 

--- a/browser-polyfill.js
+++ b/browser-polyfill.js
@@ -21,4 +21,4 @@
         // Firefox already has the browser.* namespace
         global.browser = browser;
     }
-})(typeof globalThis !== 'undefined' ? globalThis : typeof window !== 'undefined' ? window : this); 
+})(typeof globalThis !== 'undefined' ? globalThis : typeof window !== 'undefined' ? window : this);

--- a/manifest.json
+++ b/manifest.json
@@ -1,1 +1,26 @@
-{"manifest_version":2,"version":"1.3.3","name":"GrinnellPlans NewLove","description":"Shows only new planlove in the quicklove page.","content_scripts":[{"matches":["*://*.grinnellplans.com/search.php?mysearch=*&planlove=1*"],"js":["newlove.user.js"]}],"permissions":["*://*.grinnellplans.com/search.php?mysearch=*&planlove=1*"]}
+{
+  "manifest_version": 3,
+  "name": "GrinnellPlans NewLove",
+  "version": "2.0.0",
+  "description": "Shows only new planlove in the quicklove page.",
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "newlove@grinnellplans.com",
+      "strict_min_version": "109.0"
+    }
+  },
+  "permissions": [
+    "storage",
+    "contextMenus"
+  ],
+  "host_permissions": [
+    "*://*.grinnellplans.com/*"
+  ],
+  "content_scripts": [{
+    "matches": ["*://*.grinnellplans.com/search.php?mysearch=*&planlove=1*"],
+    "js": ["browser-polyfill.js", "newlove.user.js"]
+  }],
+  "action": {
+    "default_title": "GrinnellPlans NewLove"
+  }
+}

--- a/manifest.json
+++ b/manifest.json
@@ -10,8 +10,7 @@
     }
   },
   "permissions": [
-    "storage",
-    "contextMenus"
+    "storage"
   ],
   "host_permissions": [
     "*://*.grinnellplans.com/*"

--- a/newlove.user.js
+++ b/newlove.user.js
@@ -21,9 +21,10 @@
 // 1.2 - Erin [nichols] reworked this to work in Chrome!
 // 1.3 - Use native JSON for storage, fix problems with FF4
 // 1.4 - Updates for GreaseMonkey 3.0
+// 2.0 - Updates for Firefox 109
 // ==UserScript==
 // @name           NewLove
-// @version        1.4.1
+// @version        2.0.0
 // @namespace      http://www.grinnellplans.com
 // @description    Shows only new planlove in the quicklove page.
 // @downloadUrl    https://github.com/grinnellplans/Newlove/raw/master/newlove.user.js

--- a/newlove.user.js
+++ b/newlove.user.js
@@ -21,7 +21,7 @@
 // 1.2 - Erin [nichols] reworked this to work in Chrome!
 // 1.3 - Use native JSON for storage, fix problems with FF4
 // 1.4 - Updates for GreaseMonkey 3.0
-// 2.0 - Updates for Chromium Manifest V3, native Firefox extension
+// 2.0 - Updates for Chromium Manifest V3, native Firefox extension, buttons to replace context menu
 // ==UserScript==
 // @name           NewLove
 // @version        2.0.0
@@ -36,8 +36,6 @@
 // @match          https://www.grinnellplans.com/search.php?mysearch=*&planlove=1*
 // @include        https://grinnellplans.com/search.php?mysearch=*&planlove=1*
 // @match          https://grinnellplans.com/search.php?mysearch=*&planlove=1*
-// @grant          GM_registerMenuCommand
-// @grant          GM_log
 // ==/UserScript==
 
 /* Credit Douglas Crockford <http://javascript.crockford.com/remedial.html> */
@@ -57,20 +55,67 @@ const arrayContains = (arr, obj) => {
     return arr.some(item => item.trim() === obj.trim());
 };
 
-// Reset the username and history (simulate a fresh install)
-const resetValues = async () => {
-    if (window.confirm("Reset username and saved planlove?")) {
+// Add control buttons to the page
+const addControlButtons = () => {
+    // Find the planlove checkbox and label
+    const planloveCheckbox = document.querySelector('input[name="planlove"]');
+    if (!planloveCheckbox) return;
+
+    // Find the text node containing "Planlove"
+    let labelNode = planloveCheckbox.parentNode.lastChild;
+    if (!labelNode) return;
+
+    // Create container for buttons
+    const buttonContainer = document.createElement('span');
+    buttonContainer.style.marginLeft = '10px';
+    buttonContainer.style.display = 'inline-flex';
+    buttonContainer.style.alignItems = 'center';
+    buttonContainer.style.gap = '5px';
+
+    // Create Reset Username button
+    const resetButton = document.createElement('button');
+    resetButton.textContent = 'Reset Username';
+    resetButton.style.margin = '0';
+    resetButton.onclick = async () => {
+        const url = new URL(window.location.href);
+        const guessUsername = url.searchParams.get("mysearch");
         await browser.storage.local.remove(["username", `planloveHash${guessUsername}`]);
+        window.location.reload();
+    };
+
+    // Create Save as Unread button
+    const saveButton = document.createElement('button');
+    saveButton.textContent = 'Save as Unread';
+    saveButton.style.margin = '0';
+    saveButton.onclick = async () => {
+        const url = new URL(window.location.href);
+        const guessUsername = url.searchParams.get("mysearch");
+        const { [`planloveHash${guessUsername}`]: currentLove } = await browser.storage.local.get(`planloveHash${guessUsername}`);
+        await browser.storage.local.set({ [`planloveHash${guessUsername}`]: JSON.stringify(currentLove || {}) });
+    };
+
+    // Add buttons to container
+    buttonContainer.appendChild(resetButton);
+    buttonContainer.appendChild(saveButton);
+
+    // Add container after the label
+    labelNode.parentNode.appendChild(buttonContainer);
+};
+
+// Toggle visibility of hidden planlove for an author
+const toggleHiddenLove = (author, hiddenLoveContainer) => {
+    if (hiddenLoveContainer.style.display === 'none') {
+        hiddenLoveContainer.style.display = 'block';
+    } else {
+        hiddenLoveContainer.style.display = 'none';
     }
 };
 
-// Do not count new planlove as read
-const saveOldlove = async () => {
-    await browser.storage.local.set({ [`planloveHash${guessUsername}`]: JSON.stringify(oldlove) });
-};
-
 // Main function
-(async () => {
+const init = async () => {
+    // Add control buttons to the page
+    addControlButtons();
+
     // Get the username from the URL
     const url = new URL(window.location.href);
     const guessUsername = url.searchParams.get("mysearch");
@@ -109,7 +154,9 @@ const saveOldlove = async () => {
     const { [`planloveHash${guessUsername}`]: oldloveStr } = await browser.storage.local.get(`planloveHash${guessUsername}`);
     let oldlove = {};
     try {
-        oldlove = JSON.parse(oldloveStr) || {};
+        if (oldloveStr) {
+            oldlove = JSON.parse(oldloveStr);
+        }
     } catch (e) {
         console.warn('Error parsing stored planlove:', e);
     }
@@ -117,7 +164,7 @@ const saveOldlove = async () => {
     // A running list of all quicklove received
     const newlove = {};
     // Read quicklove, to be hidden
-    const toRemove = [];
+    const toHide = [];
 
     // Iterate through the list of search results
     let thisLoveNode;
@@ -127,8 +174,8 @@ const saveOldlove = async () => {
 
         // Check each lovin' against list of author's previous lovin'
         if (arrayContains(oldlove[author], thisLoveText)) {
-            // Mark for removal
-            toRemove.push(thisLoveNode);
+            // Mark for hiding instead of removal
+            toHide.push(thisLoveNode);
         }
 
         // Initialize array for author if it doesn't exist
@@ -139,23 +186,50 @@ const saveOldlove = async () => {
         newlove[author].push(thisLoveText);
     }
 
-    // Remove all old love
-    toRemove.forEach(node => node.remove());
+    // Instead of removing old love, hide it and add toggle buttons
+    const authorContainers = new Map();
+    toHide.forEach(node => {
+        const author = getAuthor(node.parentNode.parentNode);
+        if (!authorContainers.has(author)) {
+            // Create container for hidden entries
+            const container = document.createElement('div');
+            container.style.display = 'none';
+            container.className = 'hidden-love-container';
+            
+            // Create toggle button
+            const toggleButton = document.createElement('span');
+            toggleButton.textContent = ' [show old]';
+            toggleButton.style.cursor = 'pointer';
+            toggleButton.style.color = '#666';
+            toggleButton.onclick = () => toggleHiddenLove(author, container);
+            
+            // Add toggle button at the end of the author header
+            const authorHeader = node.parentNode.parentNode;
+            // Append the toggle button at the very end
+            authorHeader.appendChild(toggleButton);
+            
+            // Add container after the author's section
+            node.parentNode.parentNode.parentNode.appendChild(container);
+            
+            authorContainers.set(author, container);
+        }
+        
+        // Move node to hidden container
+        const container = authorContainers.get(author);
+        container.appendChild(node);
+    });
 
     // Store the new list of planlove
     await browser.storage.local.set({ [`planloveHash${guessUsername}`]: JSON.stringify(newlove) });
+};
 
-    // Add context menu
-    browser.runtime.onInstalled?.addListener(() => {
-        browser.contextMenus?.create({
-            id: "reset-values",
-            title: "Reset username",
-            contexts: ["action"]
-        });
-        browser.contextMenus?.create({
-            id: "save-unread",
-            title: "Save as unread",
-            contexts: ["action"]
-        });
+// Wait for the polyfill to be loaded
+if (typeof browser === 'undefined') {
+    // If browser is not defined, wait for the polyfill to be ready
+    window.addEventListener('browser-polyfill-ready', () => {
+        init();
     });
-})();
+} else {
+    // If browser is already defined, run immediately
+    init();
+}

--- a/newlove.user.js
+++ b/newlove.user.js
@@ -1,5 +1,5 @@
 /*
-   Copyright 2007-2011 Ian Young
+   Copyright 2007-2024 Ian Young and contributors
 
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -45,129 +45,116 @@ String.prototype.trim = function () {
 };
 
 // Gets the name of the author a given result is associated with
-function getAuthor(node) {
-    var links = node.getElementsByTagName('a');
+const getAuthor = (node) => {
+    const links = node.getElementsByTagName('a');
     return links[0].textContent;
-}
-
-// Check given item against all members of the given array. Returns true if the item is found in the array
-function arrayContains(arr, obj) {
-    if (!arr) return false;
-    for (var i=0; i<arr.length; i++) {
-        if (arr[i].trim() == obj.trim()) {
-            return true;
-        }
-    }
-    return false;
-}
-
-// Reset the username and history (simulate a fresh install)
-function resetValues(e) {
-    if (window.confirm("Reset username and saved planlove?")) {
-        localStorage.removeItem("username");
-        localStorage.removeItem("planloveHash" + guessUsername);
-    }
-}
-
-// Do not count new planlove as read
-function saveOldlove() {
-    localStorage.setItem("planloveHash" + guessUsername, JSON.stringify(oldlove));
-}
-
-// Compatibility proxy to only run Greasemonkey commands when in Greasemonkey.
-var rootScope = this;
-var Greasy = {
-  registerMenuCommand: function(a, b, c) {
-    if (typeof GM_registerMenuCommand != 'undefined') {
-      GM_registerMenuCommand(a, b, c);
-    }
-  }
-  , log: function(message) {
-    if (typeof GM_log != 'undefined') {
-      GM_log(message);
-    }
-  }
 };
 
-(function() {
-  // Figure out if this is actually the quicklove page, as opposed to
-  // a regular search. Hackity hack!
-  username = localStorage.getItem("username");
+// Check given item against all members of the given array
+const arrayContains = (arr, obj) => {
+    if (!arr) return false;
+    return arr.some(item => item.trim() === obj.trim());
+};
 
-  // We need to determine the username. Let's make a guess based on
-  // the current url of the page.
-  var urly = window.location.href;
-  var startIndex = urly.indexOf("mysearch=") + 9;
-  var endIndex = urly.indexOf("&", startIndex);
-  var guessUsername = urly.substring(startIndex, endIndex);
-  if (!username) {
-      // Ask for confirmation of the username
-      username = window.prompt("What's your username?\n\nIf you want to stalk other people's newlove as well as your own, enter 'everyone' here.", guessUsername).toLowerCase();
-      if (!username) return false; // give up
-      localStorage.setItem("username", username);
-  }
-  // Now, if the page we're currently on isn't searching for that
-  // username, fuggedaboudit.
-  if (username != guessUsername && username != "everyone") {
-      Greasy.log("False alarm, this isn't a quicklove page. Exiting.");
-      return false;
-  }
+// Reset the username and history (simulate a fresh install)
+const resetValues = async () => {
+    if (window.confirm("Reset username and saved planlove?")) {
+        await browser.storage.local.remove(["username", `planloveHash${guessUsername}`]);
+    }
+};
 
-  // Add items to the menu
-  Greasy.registerMenuCommand("Reset username", resetValues, "", "", "R");
-  Greasy.registerMenuCommand("Save as unread", saveOldlove, "", "", "u");
+// Do not count new planlove as read
+const saveOldlove = async () => {
+    await browser.storage.local.set({ [`planloveHash${guessUsername}`]: JSON.stringify(oldlove) });
+};
 
-  // Find all 'sub-lists' in the page
-  var loves = document.evaluate(
-          '//ul[@id="search_results"]/li//ul/li',
-          document,
-          null,
-          XPathResult.UNORDERED_NODE_ITERATOR_TYPE,
-          null);
+// Main function
+(async () => {
+    // Get the username from the URL
+    const url = new URL(window.location.href);
+    const guessUsername = url.searchParams.get("mysearch");
 
-  // Get the stored planlove from last time
-  oldlove_str = localStorage.getItem("planloveHash" + guessUsername);
+    // Get stored username
+    const { username: storedUsername } = await browser.storage.local.get("username");
+    let username = storedUsername;
 
-  // Convert from the stored string to a hashtable of arrays
-  try {
-      var oldlove = JSON.parse( oldlove_str );
-      // Test it to see if it's null
-      oldlove["foo"];
-  } catch (e) {
-      var oldlove = {};
-  }
+    if (!username) {
+        // Ask for confirmation of the username
+        username = window.prompt(
+            "What's your username?\n\nIf you want to stalk other people's newlove as well as your own, enter 'everyone' here.",
+            guessUsername
+        )?.toLowerCase();
 
-  // A running list of all quicklove received
-  var newlove = {};
-  // Read quicklove, to be hidden
-  var toRemove = []
+        if (!username) return;
+        await browser.storage.local.set({ username });
+    }
 
-  // Iterate through the list of search results
-  var thisLoveNode;
-  while ( thisLoveNode = loves.iterateNext() ) {
-      var author = getAuthor(thisLoveNode.parentNode.parentNode);
+    // Exit if not on the right page
+    if (username !== guessUsername && username !== "everyone") {
+        console.log("False alarm, this isn't a quicklove page. Exiting.");
+        return;
+    }
 
-      thisLoveText = thisLoveNode.textContent;
+    // Find all 'sub-lists' in the page
+    const loves = document.evaluate(
+        '//ul[@id="search_results"]/li//ul/li',
+        document,
+        null,
+        XPathResult.UNORDERED_NODE_ITERATOR_TYPE,
+        null
+    );
 
-      // Check each lovin' against list of author's previous lovin'
-      if (arrayContains(oldlove[author], thisLoveText)) {
-          // Mark for removal
-          toRemove.push( thisLoveNode );
-      }
+    // Get the stored planlove from last time
+    const { [`planloveHash${guessUsername}`]: oldloveStr } = await browser.storage.local.get(`planloveHash${guessUsername}`);
+    let oldlove = {};
+    try {
+        oldlove = JSON.parse(oldloveStr) || {};
+    } catch (e) {
+        console.warn('Error parsing stored planlove:', e);
+    }
 
-      // Fetch the array of planlove for the current author
-      var temp_arr = newlove[author];
-      // Create it if it doesn't exist
-      if (!newlove[author]) { newlove[author] = []; }
-      // Add it to the new list of planlove
-      newlove[author].push( thisLoveText );
-  }
+    // A running list of all quicklove received
+    const newlove = {};
+    // Read quicklove, to be hidden
+    const toRemove = [];
 
-  // Now remove all old love
-  toRemove.forEach( function( n ) {
-      n.parentNode.removeChild( n );
-  });
+    // Iterate through the list of search results
+    let thisLoveNode;
+    while (thisLoveNode = loves.iterateNext()) {
+        const author = getAuthor(thisLoveNode.parentNode.parentNode);
+        const thisLoveText = thisLoveNode.textContent;
 
-  // Store the new list of planlove, for next time
-  localStorage.setItem("planloveHash" + guessUsername, JSON.stringify(newlove));
-})()
+        // Check each lovin' against list of author's previous lovin'
+        if (arrayContains(oldlove[author], thisLoveText)) {
+            // Mark for removal
+            toRemove.push(thisLoveNode);
+        }
+
+        // Initialize array for author if it doesn't exist
+        if (!newlove[author]) {
+            newlove[author] = [];
+        }
+        // Add it to the new list of planlove
+        newlove[author].push(thisLoveText);
+    }
+
+    // Remove all old love
+    toRemove.forEach(node => node.remove());
+
+    // Store the new list of planlove
+    await browser.storage.local.set({ [`planloveHash${guessUsername}`]: JSON.stringify(newlove) });
+
+    // Add context menu
+    browser.runtime.onInstalled?.addListener(() => {
+        browser.contextMenus?.create({
+            id: "reset-values",
+            title: "Reset username",
+            contexts: ["action"]
+        });
+        browser.contextMenus?.create({
+            id: "save-unread",
+            title: "Save as unread",
+            contexts: ["action"]
+        });
+    });
+})();

--- a/newlove.user.js
+++ b/newlove.user.js
@@ -21,7 +21,7 @@
 // 1.2 - Erin [nichols] reworked this to work in Chrome!
 // 1.3 - Use native JSON for storage, fix problems with FF4
 // 1.4 - Updates for GreaseMonkey 3.0
-// 2.0 - Updates for Firefox 109
+// 2.0 - Updates for Chromium Manifest V3, native Firefox extension
 // ==UserScript==
 // @name           NewLove
 // @version        2.0.0


### PR DESCRIPTION
Honestly I just threw this into Cursor and asked it to do it for me, seems to work alright when I load it as an unpacked extension in Chrome, I honestly didn't check it in Firefox but I'll see if I can

- Update manifest to Manifest V3
- Add browser-polyfill.js for cross-browser support
- Refactor newlove.user.js to use browser extension APIs
- Update copyright year
- Modernize JavaScript syntax
- Improve error handling and storage management